### PR TITLE
updates to openapi-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ $(BINDIR)/apiserver: .init .generate_files cmd/apiserver $(NEWEST_GO_FILE)
 #################################################
 .generate_exes: $(BINDIR)/defaulter-gen \
                 $(BINDIR)/deepcopy-gen \
-                $(BINDIR)/conversion-gen
+                $(BINDIR)/conversion-gen \
+				$(BINDIR)/openapi-gen
 	touch $@
 
 $(BINDIR)/defaulter-gen: .init cmd/libs/go2idl/defaulter-gen
@@ -108,6 +109,9 @@ $(BINDIR)/deepcopy-gen: .init cmd/libs/go2idl/deepcopy-gen
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/cmd/libs/go2idl/deepcopy-gen
 
 $(BINDIR)/conversion-gen: cmd/libs/go2idl/conversion-gen
+	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/$^
+
+$(BINDIR)/openapi-gen: cmd/libs/go2idl/openapi-gen
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/$^
 
 # Regenerate all files if the gen exes changed or any "types.go" files changed

--- a/cmd/libs/go2idl/openapi-gen/main.go
+++ b/cmd/libs/go2idl/openapi-gen/main.go
@@ -21,12 +21,33 @@ package main
 
 import (
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"k8s.io/gengo/args"
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types"
 	"k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators"
 
 	"github.com/golang/glog"
 )
+
+var (
+	inputVersions = []string{
+		"api/",
+		"authentication/",
+		"authorization/",
+		"autoscaling/",
+		"batch/",
+		"certificates/",
+		"extensions/",
+		"rbac/",
+		"storage/",
+		"apps/",
+		"policy/",
+	}
+	basePath = "k8s.io/kubernetes/pkg/apis"
+)
+
 
 func main() {
 	arguments := args.Default()
@@ -34,6 +55,18 @@ func main() {
 	// Override defaults.
 	arguments.OutputFileBaseName = "openapi_generated"
 	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	arguments.OutputPackagePath = "k8s.io/kubernetes/pkg/client/listers/apps/v1beta1"
+
+	inputPath, _, _, err := parseInputVersions()
+	if err != nil {
+		glog.Fatalf("Error: %v", err)
+	}
+
+	//includedTypesOverrides, err := parseIncludedTypesOverrides()
+	if err != nil {
+		glog.Fatalf("Unexpected error: %v", err)
+	}
+	arguments.InputDirs = inputPath
 
 	// Run it.
 	if err := arguments.Execute(
@@ -44,4 +77,59 @@ func main() {
 		glog.Fatalf("Error: %v", err)
 	}
 	glog.V(2).Info("Completed successfully.")
+}
+
+func parseInputVersions() (paths []string, groups []types.GroupVersions, gvToPath map[types.GroupVersion]string, err error) {
+	var seenGroups = make(map[types.Group]*types.GroupVersions)
+	gvToPath = make(map[types.GroupVersion]string)
+	for _, input := range inputVersions {
+		gvPath, gvString := parsePathGroupVersion(input)
+		gv, err := types.ToGroupVersion(gvString)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if group, ok := seenGroups[gv.Group]; ok {
+			(*seenGroups[gv.Group]).Versions = append(group.Versions, gv.Version)
+		} else {
+			seenGroups[gv.Group] = &types.GroupVersions{
+				Group:    gv.Group,
+				Versions: []types.Version{gv.Version},
+			}
+		}
+
+		path := versionToPath(gvPath, gv.Group.String(), gv.Version.String())
+		paths = append(paths, path)
+		gvToPath[gv] = path
+	}
+	var groupNames []string
+	for groupName := range seenGroups {
+		groupNames = append(groupNames, groupName.String())
+	}
+	sort.Strings(groupNames)
+	for _, groupName := range groupNames {
+		groups = append(groups, *seenGroups[types.Group(groupName)])
+	}
+
+	return paths, groups, gvToPath, nil
+}
+
+func versionToPath(gvPath string, group string, version string) (path string) {
+	// special case for the core group
+	if group == "api" {
+		path = filepath.Join(basePath, "../api", version)
+	} else {
+		path = filepath.Join(basePath, gvPath, group, version)
+	}
+	return
+}
+
+func parsePathGroupVersion(pgvString string) (gvPath string, gvString string) {
+	subs := strings.Split(pgvString, "/")
+	length := len(subs)
+	switch length {
+	case 0, 1, 2:
+		return "", pgvString
+	default:
+		return strings.Join(subs[:length-2], "/"), strings.Join(subs[length-2:], "/")
+	}
 }


### PR DESCRIPTION
This patch fixes seg fault in `openapi-gen/main.go` and adds
a make rule to create the `./bin/openapi-gen` binary as part
of the build process.

Generated go file gets placed under `$GOPATH/src/k8s.io/kubernetes/pkg/client/listers/apps/v1beta1/openapi_generated.go`

@pmorie